### PR TITLE
change optimism, base, and eth traces jobs to run daily

### DIFF
--- a/dags/base_testnet/decode_testnet_base_blocks_daily.py
+++ b/dags/base_testnet/decode_testnet_base_blocks_daily.py
@@ -15,20 +15,20 @@ default_args = {
 
 # Instantiate the DAG
 dag = DAG(
-    "decode_testnet_base_logs_hourly",
+    "decode_testnet_base_blocks_daily",
     default_args=default_args,
-    description="DAG to decode testnet_base logs hourly",
-    schedule_interval='0 * * * *',
+    description="DAG to decode testnet_base blocks daily",
+    schedule_interval='0 0 * * *',
     catchup=False,
 )
 
 
-run_incremental_testnet_base_logs_dbt_model = BashOperator(
-    task_id='run_incremental_testnet_base_logs_dbt_model',
-    bash_command='cd /home/airflow/gcs/dags/evm-models/ && dbt run --select decoded_testnet_base_logs '
+run_incremental_testnet_base_blocks_dbt_model = BashOperator(
+    task_id='run_incremental_testnet_base_blocks_dbt_model',
+    bash_command='cd /home/airflow/gcs/dags/evm-models/ && dbt run --select decoded_testnet_base_blocks '
                  '--target testnet-base-production --vars \"{"testnet_base_raw_database": '
                  '"base_managed", "contracts_database": "contracts"}\" ',
     dag=dag
 )
 
-run_incremental_testnet_base_logs_dbt_model
+run_incremental_testnet_base_blocks_dbt_model

--- a/dags/base_testnet/decode_testnet_base_logs_daily.py
+++ b/dags/base_testnet/decode_testnet_base_logs_daily.py
@@ -15,20 +15,20 @@ default_args = {
 
 # Instantiate the DAG
 dag = DAG(
-    "decode_testnet_base_blocks_hourly",
+    "decode_testnet_base_logs_daily",
     default_args=default_args,
-    description="DAG to decode testnet_base blocks hourly",
-    schedule_interval='0 * * * *',
+    description="DAG to decode testnet_base logs daily",
+    schedule_interval='0 0 * * *',
     catchup=False,
 )
 
 
-run_incremental_testnet_base_blocks_dbt_model = BashOperator(
-    task_id='run_incremental_testnet_base_blocks_dbt_model',
-    bash_command='cd /home/airflow/gcs/dags/evm-models/ && dbt run --select decoded_testnet_base_blocks '
+run_incremental_testnet_base_logs_dbt_model = BashOperator(
+    task_id='run_incremental_testnet_base_logs_dbt_model',
+    bash_command='cd /home/airflow/gcs/dags/evm-models/ && dbt run --select decoded_testnet_base_logs '
                  '--target testnet-base-production --vars \"{"testnet_base_raw_database": '
                  '"base_managed", "contracts_database": "contracts"}\" ',
     dag=dag
 )
 
-run_incremental_testnet_base_blocks_dbt_model
+run_incremental_testnet_base_logs_dbt_model

--- a/dags/base_testnet/decode_testnet_base_traces_daily.py
+++ b/dags/base_testnet/decode_testnet_base_traces_daily.py
@@ -15,20 +15,20 @@ default_args = {
 
 # Instantiate the DAG
 dag = DAG(
-    "decode_testnet_base_transactions_hourly",
+    "decode_testnet_base_traces_daily",
     default_args=default_args,
-    description="DAG to decode testnet_base transactions hourly",
-    schedule_interval='0 * * * *',
+    description="DAG to decode testnet_base traces every day",
+    schedule_interval='0 0 * * *',
     catchup=False,
 )
 
 
-run_incremental_testnet_base_transactions_dbt_model = BashOperator(
-    task_id='run_incremental_testnet_base_transactions_dbt_model',
-    bash_command='cd /home/airflow/gcs/dags/evm-models/ && dbt run --select decoded_testnet_base_transactions '
+run_incremental_testnet_base_traces_dbt_model = BashOperator(
+    task_id='run_incremental_testnet_base_traces_dbt_model',
+    bash_command='cd /home/airflow/gcs/dags/evm-models/ && dbt run --select decoded_testnet_base_traces '
                  '--target testnet-base-production --vars \"{"testnet_base_raw_database": '
                  '"base_managed", "contracts_database": "contracts"}\" ',
     dag=dag
 )
 
-run_incremental_testnet_base_transactions_dbt_model
+run_incremental_testnet_base_traces_dbt_model

--- a/dags/base_testnet/decode_testnet_base_transactions_daily.py
+++ b/dags/base_testnet/decode_testnet_base_transactions_daily.py
@@ -15,20 +15,20 @@ default_args = {
 
 # Instantiate the DAG
 dag = DAG(
-    "decode_testnet_base_traces",
+    "decode_testnet_base_transactions_daily",
     default_args=default_args,
-    description="DAG to decode testnet_base traces every 12 hours",
-    schedule_interval='0 */12 * * *',
+    description="DAG to decode testnet_base transactions daily",
+    schedule_interval='0 0 * * *',
     catchup=False,
 )
 
 
-run_incremental_testnet_base_traces_dbt_model = BashOperator(
-    task_id='run_incremental_testnet_base_traces_dbt_model',
-    bash_command='cd /home/airflow/gcs/dags/evm-models/ && dbt run --select decoded_testnet_base_traces '
+run_incremental_testnet_base_transactions_dbt_model = BashOperator(
+    task_id='run_incremental_testnet_base_transactions_dbt_model',
+    bash_command='cd /home/airflow/gcs/dags/evm-models/ && dbt run --select decoded_testnet_base_transactions '
                  '--target testnet-base-production --vars \"{"testnet_base_raw_database": '
                  '"base_managed", "contracts_database": "contracts"}\" ',
     dag=dag
 )
 
-run_incremental_testnet_base_traces_dbt_model
+run_incremental_testnet_base_transactions_dbt_model

--- a/dags/decode_traces_daily.py
+++ b/dags/decode_traces_daily.py
@@ -15,10 +15,10 @@ default_args = {
 
 # Instantiate the DAG
 dag = DAG(
-    "decode_traces_12_hours",
+    "decode_traces_daily",
     default_args=default_args,
-    description="DAG to decode traces every 12 hours",
-    schedule_interval='0 */12 * * *',
+    description="DAG to decode traces every 24 hrs",
+    schedule_interval='0 0 * * *',
     catchup=False,
 )
 

--- a/dags/optimism/decode_optimism_blocks_daily.py
+++ b/dags/optimism/decode_optimism_blocks_daily.py
@@ -15,20 +15,20 @@ default_args = {
 
 # Instantiate the DAG
 dag = DAG(
-    "decode_optimism_logs_hourly",
+    "decode_optimism_blocks_daily",
     default_args=default_args,
-    description="DAG to decode optimism logs hourly",
-    schedule_interval='0 * * * *',
+    description="DAG to decode optimism blocks daily",
+    schedule_interval='0 0 * * *',
     catchup=False,
 )
 
 
-run_incremental_optimism_logs_dbt_model = BashOperator(
-    task_id='run_incremental_optimism_logs_dbt_model',
-    bash_command='cd /home/airflow/gcs/dags/evm-models/ && dbt run --select decoded_optimism_logs '
+run_incremental_optimism_blocks_dbt_model = BashOperator(
+    task_id='run_incremental_optimism_blocks_dbt_model',
+    bash_command='cd /home/airflow/gcs/dags/evm-models/ && dbt run --select decoded_optimism_blocks '
                  '--target optimism-production --vars \"{"optimism_raw_database": '
                  '"optimism_managed", "contracts_database": "contracts"}\" ',
     dag=dag
 )
 
-run_incremental_optimism_logs_dbt_model
+run_incremental_optimism_blocks_dbt_model

--- a/dags/optimism/decode_optimism_logs_daily.py
+++ b/dags/optimism/decode_optimism_logs_daily.py
@@ -15,20 +15,20 @@ default_args = {
 
 # Instantiate the DAG
 dag = DAG(
-    "decode_optimism_blocks_hourly",
+    "decode_optimism_logs_daily",
     default_args=default_args,
-    description="DAG to decode optimism blocks hourly",
-    schedule_interval='0 * * * *',
+    description="DAG to decode optimism logs daily",
+    schedule_interval='0 0 * * *',
     catchup=False,
 )
 
 
-run_incremental_optimism_blocks_dbt_model = BashOperator(
-    task_id='run_incremental_optimism_blocks_dbt_model',
-    bash_command='cd /home/airflow/gcs/dags/evm-models/ && dbt run --select decoded_optimism_blocks '
+run_incremental_optimism_logs_dbt_model = BashOperator(
+    task_id='run_incremental_optimism_logs_dbt_model',
+    bash_command='cd /home/airflow/gcs/dags/evm-models/ && dbt run --select decoded_optimism_logs '
                  '--target optimism-production --vars \"{"optimism_raw_database": '
                  '"optimism_managed", "contracts_database": "contracts"}\" ',
     dag=dag
 )
 
-run_incremental_optimism_blocks_dbt_model
+run_incremental_optimism_logs_dbt_model

--- a/dags/optimism/decode_optimism_traces_daily.py
+++ b/dags/optimism/decode_optimism_traces_daily.py
@@ -15,10 +15,10 @@ default_args = {
 
 # Instantiate the DAG
 dag = DAG(
-    "decode_optimism_traces_12_hours",
+    "decode_optimism_traces_daily",
     default_args=default_args,
-    description="DAG to decode optimism traces hourly",
-    schedule_interval='0 */12 * * *',
+    description="DAG to decode optimism traces daily",
+    schedule_interval='0 0 * * *',
     catchup=False,
 )
 

--- a/dags/optimism/decode_optimism_transactions_daily.py
+++ b/dags/optimism/decode_optimism_transactions_daily.py
@@ -15,10 +15,10 @@ default_args = {
 
 # Instantiate the DAG
 dag = DAG(
-    "decode_optimism_transactions_hourly",
+    "decode_optimism_transactions_daily",
     default_args=default_args,
-    description="DAG to decode optimism transactions hourly",
-    schedule_interval='0 * * * *',
+    description="DAG to decode optimism transactions daily",
+    schedule_interval='0 0 * * *',
     catchup=False,
 )
 


### PR DESCRIPTION
This PR changes our optimism, base, and eth traces jobs to run daily instead of every hour. It should bring down our snowflake costs. 